### PR TITLE
Add sql test data and Makefile test rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,17 @@
 MODULES = match_timestamps.lua pretty.lua
+TEST_DB = sample_history.db
+TEST_SQL = sample_history.sql
 
 histdb.lua: build.lua init.lua $(MODULES)
-	lua build.lua --entrypoint init.lua --output histdb.lua $(MODULES)
+	lua5.4 build.lua --entrypoint init.lua --output histdb.lua $(MODULES)
+
+$(TEST_DB): $(TEST_SQL)
+	sqlite3 $@ < $(TEST_SQL)
+	sqlite3 $@ "INSERT INTO history (hostname, session_id, timestamp, history_id, cwd, entry, duration, exit_status) VALUES ('todayhost', '5', strftime('%s','now'), 7, '/tmp', 'run today', 1, 0);"
+
+test: histdb.lua $(TEST_DB)
+	lua5.4 match_timestamps_test.lua
+	HISTDB_PATH=$(PWD)/$(TEST_DB) lua5.4 invariants_test.lua
 
 clean:
-	rm -f histdb.lua
+	rm -f histdb.lua $(TEST_DB)

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,6 @@ histdb.lua: build.lua init.lua $(MODULES)
 
 $(TEST_DB): $(TEST_SQL)
 	sqlite3 $@ < $(TEST_SQL)
-	sqlite3 $@ "INSERT INTO history (hostname, session_id, timestamp, history_id, cwd, entry, duration, exit_status) VALUES ('todayhost', '5', strftime('%s','now'), 7, '/tmp', 'run today', 1, 0);"
 
 test: histdb.lua $(TEST_DB)
 	lua5.4 match_timestamps_test.lua

--- a/invariants_test.lua
+++ b/invariants_test.lua
@@ -60,6 +60,14 @@ local function count_tuples(results)
 end
 
 local function assert_result_sets_match_unordered(results_a, results_b)
+  assert(#results_a == #results_b,
+         string.format('result set row count mismatch:\n  a: %d\n  b: %d',
+                       #results_a, #results_b))
+
+  if #results_a == 0 then
+    return
+  end
+
   local columns_a = keys(results_a[1])
   local columns_b = keys(results_b[1])
 
@@ -85,6 +93,14 @@ local function assert_result_sets_match_unordered(results_a, results_b)
 end
 
 local function assert_result_sets_match_ordered(results_a, results_b)
+  assert(#results_a == #results_b,
+         string.format('result set row count mismatch:\n  a: %d\n  b: %d',
+                       #results_a, #results_b))
+
+  if #results_a == 0 then
+    return
+  end
+
   local columns_a = keys(results_a[1])
   local columns_b = keys(results_b[1])
 
@@ -93,9 +109,6 @@ local function assert_result_sets_match_ordered(results_a, results_b)
   for i = 1, #columns_a do
     assert(columns_a[1] == columns_b[1])
   end
-
-  -- the number of rows in each should match
-  assert(#results_a == #results_b, string.format('result set row count mismatch:\n  a: %d\n  b: %d', #results_a, #results_b))
 
   for row = 1, #results_a do
     local row_a = results_a[row]

--- a/sample_history.sql
+++ b/sample_history.sql
@@ -1,0 +1,18 @@
+CREATE TABLE history (
+  hostname TEXT,
+  session_id TEXT,
+  timestamp INTEGER,
+  history_id INTEGER,
+  cwd TEXT,
+  entry TEXT,
+  duration INTEGER,
+  exit_status INTEGER
+);
+
+INSERT INTO history (hostname, session_id, timestamp, history_id, cwd, entry, duration, exit_status) VALUES
+  ('host1', '1', 1640995200, 1, '/home/rob', 'vim file1', 10, 0),
+  ('host1', '1', 1640995260, 2, '/home/rob', 'ls -l', 2, 0),
+  ('host1', '2', 1641081600, 3, '/home/rob/project', 'git status', 3, 0),
+  ('host1', '2', 1641168000, 4, '/home/rob', 'vim file2', 20, 0),
+  ('host2', '3', 1641254400, 5, '/home/rob', 'echo test', 1, 0),
+  ('host2', '4', NULL, 6, '/home/rob', 'incomplete', 1, 1);

--- a/sample_history.sql
+++ b/sample_history.sql
@@ -1,3 +1,4 @@
+DROP TABLE IF EXISTS history;
 CREATE TABLE history (
   hostname TEXT,
   session_id TEXT,


### PR DESCRIPTION
## Summary
- add `sample_history.sql` with example history table and rows
- update `Makefile` with a `test` target that builds a test DB from the SQL file and runs both Lua tests
- remove the unusual `.RECIPEPREFIX` directive and use standard tab-indented recipes

## Testing
- `make clean`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68465601209c83249b29dee1cf8a4e4c