### PR TITLE
Ensure timestamp MATCH invariant is exercised

### DIFF
--- a/sample_history.sql
+++ b/sample_history.sql
@@ -16,4 +16,5 @@ INSERT INTO history (hostname, session_id, timestamp, history_id, cwd, entry, du
   ('host1', '017e1815-f800-715d-88dc-0590f94e9710', 1641081600, 3, '/home/rob/project', 'git status', 3, 0),
   ('host1', '017e1815-f800-715d-88dc-0590f94e9710', 1641168000, 4, '/home/rob', 'vim file2', 20, 0),
   ('host2', '017e2262-b000-78d9-bed8-c98696ada0be', 1641254400, 5, '/home/rob', 'echo test', 1, 0),
-  ('host2', NULL, NULL, 6, '/home/rob', 'incomplete', 1, 1);
+  ('host2', NULL, NULL, 6, '/home/rob', 'incomplete', 1, 1),
+  ('host3', 'session_today', CAST(strftime('%s','now') AS INTEGER), 7, '/home/rob', 'today cmd', 1, 0);


### PR DESCRIPTION
## Summary
- add a row dated `now` so that `timestamp MATCH 'today'` queries return data
- demonstrate invariant failures and reverts

## Testing
- `make clean`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6846f71840e483248395cbfd2510e75b